### PR TITLE
Fix GCAL env var name

### DIFF
--- a/mcp-google-calendar/README.md
+++ b/mcp-google-calendar/README.md
@@ -131,7 +131,7 @@ log.Fatal(server.ServeHTTP(":8080", s))
 3. `credentials.json` のパスを環境変数で渡す：
 
    ```bash
-   export GCAL_CREDENTIALS=$HOME/.config/gcal_mcp/credentials.json
+   export GCAL_CREDENTIALS_PATH=$HOME/.config/gcal_mcp/credentials.json
    ```
 4. 初回起動：
 


### PR DESCRIPTION
## Summary
- update Google Calendar README to use `GCAL_CREDENTIALS_PATH`

## Testing
- `go vet ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684191513110832a86f86b4be8c11741