### PR TITLE
Fix event location pointer issue

### DIFF
--- a/mcp-google-calendar/internal/infrastructure/gcal/google_calendar_adapter.go
+++ b/mcp-google-calendar/internal/infrastructure/gcal/google_calendar_adapter.go
@@ -174,6 +174,7 @@ func (g *googleCalendarService) CreateEvent(ctx context.Context, calID string, e
 		return nil, errors.NewAPIError("create_event", errorMsg, 500, err)
 	}
 
+	loc := created.Location
 	return &domain.Event{
 		ID:          created.Id,
 		Title:       created.Summary,
@@ -188,7 +189,7 @@ func (g *googleCalendarService) CreateEvent(ctx context.Context, calID string, e
 			Date:     created.End.Date,
 			TimeZone: created.End.TimeZone,
 		},
-		Location:  &created.Location,
+		Location:  &loc,
 		Attendees: getEventAttendees(created.Attendees),
 	}, nil
 }

--- a/mcp-google-calendar/internal/infrastructure/gcal/google_calendar_adapter_test.go
+++ b/mcp-google-calendar/internal/infrastructure/gcal/google_calendar_adapter_test.go
@@ -77,3 +77,30 @@ func TestGoogleCalendarAdapter_CreateEvent(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, wantEvent, got)
 }
+
+func TestGoogleCalendarAdapter_CreateEventLocationCopy(t *testing.T) {
+	wantEvent := &domain.Event{
+		ID:       "evt1",
+		Title:    "MTG",
+		Start:    domain.DateTime{DateTime: "2025-01-01T00:00:00Z"},
+		End:      domain.DateTime{DateTime: "2025-01-01T01:00:00Z"},
+		Location: func() *string { s := "Room 1"; return &s }(),
+	}
+
+	mockSvc := &mockCalendarService{insertResp: wantEvent}
+	adapter := &GoogleCalendarAdapter{service: mockSvc, limiter: NewRateLimiter()}
+
+	got, err := adapter.CreateEvent(context.Background(), "primary", &domain.Event{
+		Title:    wantEvent.Title,
+		Start:    wantEvent.Start,
+		End:      wantEvent.End,
+		Location: wantEvent.Location,
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, got.Location)
+	if got.Location == wantEvent.Location {
+		t.Errorf("location pointer should be copied")
+	}
+	require.Equal(t, *wantEvent.Location, *got.Location)
+}


### PR DESCRIPTION
## Summary
- fix bug in google_calendar_adapter that returned pointer to short-lived memory
- test event location pointer returned from adapter

## Testing
- `GOTOOLCHAIN=local go test ./...` *(fails: go.mod requires go >= 1.24.3)*
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68418d085888832aa9aa55e603cd65b1